### PR TITLE
Adding a querystring to ContactID so that Contact Groups may be added using this Go client

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -28,7 +28,7 @@ type Test struct {
 	Port int `json:"Port" querystring:"Port"`
 
 	// Contact group ID - will return int of contact group used else 0
-	ContactID int `json:"ContactID"`
+	ContactID int `json:"ContactID" querystring:"ContactGroup"`
 
 	// Current status at last test
 	Status string `json:"Status"`


### PR DESCRIPTION
Adding a querystring to ContactID so that Contact Groups may be added using this Go client.
The query string for the contactID item is missing from the Test struct.  This causes API calls to status cake to fail when attempting to add or update a contact group.

This fix adds the query string in place so that the calls succeed.
