### PR TITLE
StatusCake API returns TriggerRate as string and Go couldn't unmarshall

### DIFF
--- a/responses.go
+++ b/responses.go
@@ -43,7 +43,7 @@ type detailResponse struct {
 	ProcessingOn    string   `json:"ProcessingOn"`
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
-	TriggerRate     int      `json:"TriggerRate"`
+	TriggerRate     int      `json:"string,TriggerRate"`
 }
 
 func (d *detailResponse) test() *Test {


### PR DESCRIPTION
This was causing the following error:

```
=== RUN   TestAccStatusCake_basic
--- FAIL: TestAccStatusCake_basic (1.22s)
	testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:

		* statuscake_test.google: 1 error(s) occurred:

		* statuscake_test.google: Error Getting StatusCake Test Details for 2028827: Error: json: cannot unmarshal string into Go struct field detailResponse.TriggerRate of type int
```

This change fixes the issue:

```
% make testacc TEST=./builtin/providers/statuscake                                                                                     130 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
         2017/04/07 15:40:04 Generated command/internal_plugin_list.go
^R
TF_ACC=1 go test ./builtin/providers/statuscake -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccStatusCake_basic
--- PASS: TestAccStatusCake_basic (2.58s)
=== RUN   TestAccStatusCake_tcp
--- PASS: TestAccStatusCake_tcp (2.16s)
=== RUN   TestAccStatusCake_withUpdate
--- PASS: TestAccStatusCake_withUpdate (7.26s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/statuscake	12.016s
```