### PR TITLE
Add support for custom HTTP Headers.

### DIFF
--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -3,6 +3,7 @@
   "TestType": "HTTP",
   "Paused": false,
   "WebsiteName": "NL",
+  "CustomHeader": "{\"some\":{\"json\": [\"value\"]}}",
   "ContactGroup": "StatusCake Alerts",
   "ContactID": 536,
   "Status": "Up",

--- a/responses.go
+++ b/responses.go
@@ -27,6 +27,7 @@ type detailResponse struct {
 	ContactID       int      `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
+	CustomHeader    string   `json:"CustomHeader"`
 	CheckRate       int      `json:"CheckRate"`
 	Timeout         int      `json:"Timeout"`
 	LogoImage       string   `json:"LogoImage"`
@@ -53,6 +54,7 @@ func (d *detailResponse) test() *Test {
 		Paused:        d.Paused,
 		WebsiteName:   d.WebsiteName,
 		WebsiteURL:    d.URI,
+		CustomHeader:  d.CustomHeader,
 		ContactID:     d.ContactID,
 		Status:        d.Status,
 		Uptime:        d.Uptime,

--- a/tests.go
+++ b/tests.go
@@ -21,6 +21,9 @@ type Test struct {
 	// Website name. Tags are stripped out
 	WebsiteName string `json:"WebsiteName" querystring:"WebsiteName"`
 
+	// CustomHeader. A special header that will be sent along with the HTTP tests.
+	CustomHeader string `json:"CustomHeader" querystring:"CustomHeader"`
+
 	// Test location, either an IP (for TCP and Ping) or a fully qualified URL for other TestTypes
 	WebsiteURL string `json:"WebsiteURL" querystring:"WebsiteURL"`
 
@@ -135,6 +138,10 @@ func (t *Test) Validate() error {
 
 	if t.TriggerRate < 0 || t.TriggerRate > 59 {
 		e["TriggerRate"] = "must be between 0 and 59"
+	}
+	var jsonVerifiable map[string]interface{}
+	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
+		e["CustomHeader"] = "must be provided as json string"
 	}
 
 	if len(e) > 0 {

--- a/tests_test.go
+++ b/tests_test.go
@@ -25,6 +25,7 @@ func TestTest_Validate(t *testing.T) {
 		RealBrowser:  100,
 		TriggerRate:  100,
 		CheckRate:    100000,
+		CustomHeader: "here be dragons",
 		WebsiteName:  "",
 		WebsiteURL:   "",
 	}
@@ -43,6 +44,7 @@ func TestTest_Validate(t *testing.T) {
 	assert.Contains(message, "TestType must be HTTP, TCP, or PING")
 	assert.Contains(message, "RealBrowser must be 0 or 1")
 	assert.Contains(message, "TriggerRate must be between 0 and 59")
+	assert.Contains(message, "CustomHeader must be provided as json string")
 
 	test.Timeout = 10
 	test.Confirmation = 2
@@ -54,6 +56,7 @@ func TestTest_Validate(t *testing.T) {
 	test.CheckRate = 10
 	test.WebsiteName = "Foo"
 	test.WebsiteURL = "http://example.com"
+	test.CustomHeader = `{"test": 15}`
 
 	err = test.Validate()
 	assert.Nil(err)
@@ -66,6 +69,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		TestID:        123,
 		Paused:        true,
 		WebsiteName:   "Foo Bar",
+		CustomHeader:  `{"some":{"json": ["value"]}}`,
 		WebsiteURL:    "http://example.com",
 		Port:          3000,
 		NodeLocations: []string{"foo", "bar"},
@@ -93,6 +97,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		"Paused":        {"1"},
 		"WebsiteName":   {"Foo Bar"},
 		"WebsiteURL":    {"http://example.com"},
+		"CustomHeader":  {`{"some":{"json": ["value"]}}`},
 		"Port":          {"3000"},
 		"NodeLocations": {"foo,bar"},
 		"Timeout":       {"11"},
@@ -279,6 +284,7 @@ func TestTests_Detail_OK(t *testing.T) {
 	assert.Equal(test.TestType, "HTTP")
 	assert.Equal(test.Paused, false)
 	assert.Equal(test.WebsiteName, "NL")
+	assert.Equal(test.CustomHeader, `{"some":{"json": ["value"]}}`)
 	assert.Equal(test.ContactID, 536)
 	assert.Equal(test.Status, "Up")
 	assert.Equal(test.Uptime, 0.0)


### PR DESCRIPTION
Hello friends. First of all: thanks for providing this API client!

In order to get alongside with certain spam protection, we send a custom header along with our Statuscake tests. So in order for this to function properly, we need the support for the API Endpoint's CustomHeaders field. Added + tested it. Hope you're pleased :)

Feedback of any sort very welcome.