### PR TITLE
Adding FinalEndpoint Test option

### DIFF
--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -27,5 +27,6 @@
   "ProcessingOn": "dalas.localdomain",
   "DownTimes": "0",
   "UseJar": false,
-  "PostRaw": ""
+  "PostRaw": "",
+  "FinalEndpoint": ""
 }

--- a/responses.go
+++ b/responses.go
@@ -51,6 +51,7 @@ type detailResponse struct {
 	TriggerRate     int      `json:"TriggerRate,string"`
 	UseJar          bool     `json:"UseJar"`
 	PostRaw         string   `json:"PostRaw"`
+	FinalEndpoint   string   `json:"FinalEndpoint"`
 	StatusCodes     []string `json:"StatusCodes"`
 }
 
@@ -77,6 +78,7 @@ func (d *detailResponse) test() *Test {
 		TriggerRate:   d.TriggerRate,
 		UseJar:        d.UseJar,
 		PostRaw:       d.PostRaw,
-		StatusCodes:   strings.Join(d.StatusCodes[:],","),
+		FinalEndpoint: d.FinalEndpoint,
+		StatusCodes:   strings.Join(d.StatusCodes[:], ","),
 	}
 }

--- a/tests.go
+++ b/tests.go
@@ -100,6 +100,9 @@ type Test struct {
 
 	// Raw POST data seperated by an ampersand
 	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
+
+	// Use to specify the expected Final URL in the testing process
+	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
 }
 
 // Validate checks if the Test is valid. If it's invalid, it returns a ValidationError with all invalid fields. It returns nil otherwise.
@@ -148,6 +151,10 @@ func (t *Test) Validate() error {
 
 	if t.PostRaw != "" && t.TestType != "HTTP" {
 		e["PostRaw"] = "must be HTTP to submit a POST request"
+	}
+
+	if t.FinalEndpoint != "" && t.TestType != "HTTP" {
+		e["FinalEndpoint"] = "must be a Valid URL"
 	}
 	var jsonVerifiable map[string]interface{}
 	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {

--- a/tests_test.go
+++ b/tests_test.go
@@ -120,6 +120,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		"StatusCodes":   {"500"},
 		"UseJar":        {"0"},
 		"PostRaw":       {""},
+		"FinalEndpoint": {""},
 	}
 
 	assert.Equal(expected, test.ToURLValues())


### PR DESCRIPTION
The `FinalEndpoint` field was added and documented here https://www.statuscake.com/api/Tests/Updating%20Inserting%20and%20Deleting%20Tests.md

This PR will add the option to the library