### PR TITLE
support multiple contact IDs using strings instead of ints. 

### DIFF
--- a/fixtures/tests_all_ok.json
+++ b/fixtures/tests_all_ok.json
@@ -5,7 +5,7 @@
       "TestType": "HTTP",
       "WebsiteName": "www 1",
       "ContactGroup": null,
-      "ContactID": 1,
+      "ContactID": "1",
       "Status": "Up",
       "Uptime": 100
   },
@@ -15,7 +15,7 @@
       "TestType": "HTTP",
       "WebsiteName": "www 2",
       "ContactGroup": null,
-      "ContactID": 2,
+      "ContactID": "2",
       "Status": "Down",
       "Uptime": 0
   }

--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -6,7 +6,7 @@
   "CustomHeader": "{\"some\":{\"json\": [\"value\"]}}",
   "UserAgent": "product/version (comment)",
   "ContactGroup": "StatusCake Alerts",
-  "ContactID": 536,
+  "ContactID": "536",
   "Status": "Up",
   "Uptime": 0,
   "CheckRate": 60,

--- a/responses.go
+++ b/responses.go
@@ -28,7 +28,7 @@ type detailResponse struct {
 	Paused          bool     `json:"Paused"`
 	WebsiteName     string   `json:"WebsiteName"`
 	URI             string   `json:"URI"`
-	ContactID       string    `json:"ContactID"`
+	ContactID       string   `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
 	CustomHeader    string   `json:"CustomHeader"`

--- a/responses.go
+++ b/responses.go
@@ -28,7 +28,7 @@ type detailResponse struct {
 	Paused          bool     `json:"Paused"`
 	WebsiteName     string   `json:"WebsiteName"`
 	URI             string   `json:"URI"`
-	ContactID       int      `json:"ContactID"`
+	ContactID       string    `json:"ContactID"`
 	Status          string   `json:"Status"`
 	Uptime          float64  `json:"Uptime"`
 	CustomHeader    string   `json:"CustomHeader"`

--- a/tests.go
+++ b/tests.go
@@ -34,7 +34,7 @@ type Test struct {
 	Port int `json:"Port" querystring:"Port"`
 
 	// Contact group ID - will return int of contact group used else 0
-	ContactID int `json:"ContactID" querystring:"ContactGroup"`
+	ContactID string `json:"ContactID" querystring:"ContactGroup"`
 
 	// Current status at last test
 	Status string `json:"Status"`

--- a/tests_test.go
+++ b/tests_test.go
@@ -77,6 +77,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		PingURL:        "http://example.com/ping",
 		Confirmation:   1,
 		CheckRate:      500,
+    ContactID:      "1,2",
 		BasicUser:      "myuser",
 		BasicPass:      "mypass",
 		Public:         1,
@@ -104,7 +105,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		"Timeout":        {"11"},
 		"PingURL":        {"http://example.com/ping"},
 		"Confirmation":   {"1"},
-		"ContactGroup":   {"0"}, //defaults to 0 when not provided
+		"ContactGroup":   {"1,2"},
 		"CheckRate":      {"500"},
 		"BasicUser":      {"myuser"},
 		"BasicPass":      {"mypass"},

--- a/tests_test.go
+++ b/tests_test.go
@@ -154,7 +154,7 @@ func TestTests_All(t *testing.T) {
 		Paused:      false,
 		TestType:    "HTTP",
 		WebsiteName: "www 1",
-		ContactID:   1,
+		ContactID:   "1",
 		Status:      "Up",
 		Uptime:      100,
 	}
@@ -165,7 +165,7 @@ func TestTests_All(t *testing.T) {
 		Paused:      true,
 		TestType:    "HTTP",
 		WebsiteName: "www 2",
-		ContactID:   2,
+		ContactID:   "2",
 		Status:      "Down",
 		Uptime:      0,
 	}
@@ -291,7 +291,7 @@ func TestTests_Detail_OK(t *testing.T) {
 	assert.Equal(test.WebsiteName, "NL")
 	assert.Equal(test.CustomHeader, `{"some":{"json": ["value"]}}`)
 	assert.Equal(test.UserAgent, "product/version (comment)")
-	assert.Equal(test.ContactID, 536)
+	assert.Equal(test.ContactID, "536")
 	assert.Equal(test.Status, "Up")
 	assert.Equal(test.Uptime, 0.0)
 	assert.Equal(test.CheckRate, 60)

--- a/tests_test.go
+++ b/tests_test.go
@@ -77,7 +77,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		PingURL:        "http://example.com/ping",
 		Confirmation:   1,
 		CheckRate:      500,
-    ContactID:      "1,2",
+		ContactID:      "1,2",
 		BasicUser:      "myuser",
 		BasicPass:      "mypass",
 		Public:         1,


### PR DESCRIPTION
Closes #21.