### PR TITLE
Changing UseJar to INT to match api behavior

### DIFF
--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -27,7 +27,7 @@
   "ProcessingState": "Pretest",
   "ProcessingOn": "dalas.localdomain",
   "DownTimes": "0",
-  "UseJar": false,
+  "UseJar": 0,
   "PostRaw": "",
   "FinalEndpoint": "",
   "FollowRedirect": false

--- a/responses.go
+++ b/responses.go
@@ -50,7 +50,7 @@ type detailResponse struct {
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
 	TriggerRate     int      `json:"TriggerRate,string"`
-	UseJar          bool     `json:"UseJar"`
+	UseJar          int      `json:"UseJar"`
 	PostRaw         string   `json:"PostRaw"`
 	FinalEndpoint   string   `json:"FinalEndpoint"`
 	FollowRedirect  bool     `json:"FollowRedirect"`

--- a/tests.go
+++ b/tests.go
@@ -99,7 +99,7 @@ type Test struct {
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
 
 	// Set to 1 to enable the Cookie Jar. Required for some redirects.
-	UseJar bool `json:"UseJar" querystring:"UseJar"`
+	UseJar int `json:"UseJar" querystring:"UseJar"`
 
 	// Raw POST data seperated by an ampersand
 	PostRaw string `json:"PostRaw" querystring:"PostRaw"`


### PR DESCRIPTION
  StatusCake recently started returning the `UseJar` field in their response object when doing a GET on their `API/Tests/Details`.  That field is documented as an `int` and returned as either a `0` or `1`.

This change reflects the API + documentation 