### PR TITLE
Handle errors where issues is just a string, or only message is available

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -50,6 +50,9 @@ func (e *updateError) Error() string {
 			m := fmt.Sprint(v)
 			messages = append(messages, m)
 		}
+	} else if issue, ok := e.Issues.(interface{}); ok {
+		m := fmt.Sprint(issue)
+		messages = append(messages, m)
 	}
 
 	return strings.Join(messages, ", ")

--- a/errors.go
+++ b/errors.go
@@ -34,11 +34,14 @@ func (e ValidationError) Error() string {
 }
 
 type updateError struct {
-	Issues interface{}
+	Issues  interface{}
+	Message string
 }
 
 func (e *updateError) Error() string {
 	var messages []string
+
+	messages = append(messages, e.Message)
 
 	if issues, ok := e.Issues.(map[string]interface{}); ok {
 		for k, v := range issues {

--- a/tests.go
+++ b/tests.go
@@ -283,7 +283,7 @@ func (tt *tests) Update(t *Test) (*Test, error) {
 	}
 
 	if !ur.Success {
-		return nil, &updateError{Issues: ur.Issues}
+		return nil, &updateError{Issues: ur.Issues, Message: ur.Message}
 	}
 
 	t2 := *t

--- a/tests_test.go
+++ b/tests_test.go
@@ -235,7 +235,7 @@ func TestTests_Update_ErrorWithSliceOfIssues(t *testing.T) {
 
 	require.NotNil(err)
 	assert.IsType(&updateError{}, err)
-	assert.Equal("hello, world", err.Error())
+	assert.Equal("Required Data is Missing., hello, world", err.Error())
 }
 
 func TestTests_Delete_OK(t *testing.T) {


### PR DESCRIPTION
I saw this happen when attempting to create a test with an incorrect contact ID.

The [API docs](https://www.statuscake.com/api/Tests/Updating%20Inserting%20and%20Deleting%20Tests.md) say "array", but the server response is just a bare string.

![screen shot 2018-02-01 at 11 02 26](https://user-images.githubusercontent.com/690/35657387-9832b8b0-073f-11e8-8132-4b960b1fa3d7.png)

Additional I hit a case where a test had already been deleted. In that case you don't get any `Issues` just a `Message`. So I tried to cover that case as well.
![screen shot 2018-02-01 at 16 01 26](https://user-images.githubusercontent.com/690/35665375-5864daf4-0769-11e8-8d93-3791019c2f1e.png)

(Screenshots from  [charles proxy](https://www.charlesproxy.com/))
