### PR TITLE
Support limiting NodeLocations for tests

### DIFF
--- a/cmd/statuscake/main.go
+++ b/cmd/statuscake/main.go
@@ -67,6 +67,7 @@ func cmdList(c *statuscake.Client, args ...string) error {
 		fmt.Printf("  Paused: %s\n", paused)
 		fmt.Printf("  ContactID: %d\n", t.ContactID)
 		fmt.Printf("  Uptime: %f\n", t.Uptime)
+		fmt.Printf("  NodeLocations: %s\n", t.NodeLocations)
 	}
 
 	return nil
@@ -103,6 +104,7 @@ func cmdDetail(c *statuscake.Client, args ...string) error {
 	fmt.Printf("  Paused: %s\n", paused)
 	fmt.Printf("  ContactID: %d\n", t.ContactID)
 	fmt.Printf("  Uptime: %f\n", t.Uptime)
+	fmt.Printf("  NodeLocations: %s\n", t.NodeLocations)
 
 	return nil
 }
@@ -144,10 +146,11 @@ func askInt(name string) int {
 
 func cmdCreate(c *statuscake.Client, args ...string) error {
 	t := &statuscake.Test{
-		WebsiteName: askString("WebsiteName"),
-		WebsiteURL:  askString("WebsiteURL"),
-		TestType:    askString("TestType"),
-		CheckRate:   askInt("CheckRate"),
+		WebsiteName:    askString("WebsiteName"),
+		WebsiteURL:     askString("WebsiteURL"),
+		TestType:       askString("TestType"),
+		CheckRate:      askInt("CheckRate"),
+		NodeLocations:  askString("NodeLocations"),
 	}
 
 	t2, err := c.Tests().Update(t)
@@ -181,6 +184,7 @@ func cmdUpdate(c *statuscake.Client, args ...string) error {
 	t.WebsiteURL = askString(fmt.Sprintf("WebsiteURL [%s]", t.WebsiteURL))
 	t.TestType = askString(fmt.Sprintf("TestType [%s]", t.TestType))
 	t.CheckRate = askInt(fmt.Sprintf("CheckRate [%d]", t.CheckRate))
+	t.NodeLocations = askString(fmt.Sprintf("NodeLocations [%s]", t.NodeLocations))
 
 	t2, err := c.Tests().Update(t)
 	if err != nil {

--- a/fixtures/tests_all_ok.json
+++ b/fixtures/tests_all_ok.json
@@ -7,7 +7,8 @@
       "ContactGroup": null,
       "ContactID": 1,
       "Status": "Up",
-      "Uptime": 100
+      "Uptime": 100,
+      "NodeLocations": "foo,bar"
   },
   {
       "TestID": 101,
@@ -17,6 +18,7 @@
       "ContactGroup": null,
       "ContactID": 2,
       "Status": "Down",
-      "Uptime": 0
+      "Uptime": 0,
+      "NodeLocations": "foo"
   }
 ]

--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -14,10 +14,8 @@
   "LogoImage": "",
   "WebsiteHost": "Various",
   "NodeLocations": [
-    "UK",
-    "JP",
-    "SG1",
-    "SLC"
+    "foo",
+    "bar"
   ],
   "FindString": "",
   "DoNotFind": false,

--- a/responses.go
+++ b/responses.go
@@ -74,7 +74,7 @@ func (d *detailResponse) test() *Test {
 		LogoImage:      d.LogoImage,
 		Confirmation:   d.Confirmation,
 		WebsiteHost:    d.WebsiteHost,
-		NodeLocations:  d.NodeLocations,
+		NodeLocations:  strings.Join(d.NodeLocations, ","),
 		FindString:     d.FindString,
 		DoNotFind:      d.DoNotFind,
 		Port:           d.Port,

--- a/tests.go
+++ b/tests.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+	"regexp"
 )
 
 const queryStringTag = "querystring"
@@ -43,7 +44,7 @@ type Test struct {
 	Uptime float64 `json:"Uptime"`
 
 	// Any test locations seperated by a comma (using the Node Location IDs)
-	NodeLocations []string `json:"NodeLocations" querystring:"NodeLocations"`
+	NodeLocations string `json:"NodeLocations" querystring:"NodeLocations"`
 
 	// Timeout in an int form representing seconds.
 	Timeout int `json:"Timeout" querystring:"Timeout"`
@@ -166,6 +167,17 @@ func (t *Test) Validate() error {
 	var jsonVerifiable map[string]interface{}
 	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
 		e["CustomHeader"] = "must be provided as json string"
+	}
+
+	match, err := regexp.MatchString("^([0-9A-Za-z]*[,][[:space:]]*)*[0-9A-Za-z]+$", t.NodeLocations)
+
+	if err != nil {
+		fmt.Printf("There is a problem with regexp. This is an upstream problem.\n")
+		return nil
+	}
+
+	if match != true {
+		e["NodeLocations"] = "must be test locastion IDs separated by a comma"
 	}
 
 	if len(e) > 0 {

--- a/tests_test.go
+++ b/tests_test.go
@@ -17,17 +17,18 @@ func TestTest_Validate(t *testing.T) {
 	require := require.New(t)
 
 	test := &Test{
-		Timeout:      200,
-		Confirmation: 100,
-		Public:       200,
-		Virus:        200,
-		TestType:     "FTP",
-		RealBrowser:  100,
-		TriggerRate:  100,
-		CheckRate:    100000,
-		CustomHeader: "here be dragons",
-		WebsiteName:  "",
-		WebsiteURL:   "",
+		Timeout:       200,
+		Confirmation:  100,
+		Public:        200,
+		Virus:         200,
+		TestType:      "FTP",
+		RealBrowser:   100,
+		TriggerRate:   100,
+		CheckRate:     100000,
+		CustomHeader:  "here be dragons",
+		WebsiteName:   "",
+		WebsiteURL:    "",
+		NodeLocations: "foo.bar",
 	}
 
 	err := test.Validate()
@@ -45,6 +46,7 @@ func TestTest_Validate(t *testing.T) {
 	assert.Contains(message, "RealBrowser must be 0 or 1")
 	assert.Contains(message, "TriggerRate must be between 0 and 59")
 	assert.Contains(message, "CustomHeader must be provided as json string")
+	assert.Contains(message, "NodeLocations must be test locastion IDs separated by a comma")
 
 	test.Timeout = 10
 	test.Confirmation = 2
@@ -57,6 +59,7 @@ func TestTest_Validate(t *testing.T) {
 	test.WebsiteName = "Foo"
 	test.WebsiteURL = "http://example.com"
 	test.CustomHeader = `{"test": 15}`
+	test.NodeLocations = "foo,bar"
 
 	err = test.Validate()
 	assert.Nil(err)
@@ -72,7 +75,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		CustomHeader:   `{"some":{"json": ["value"]}}`,
 		WebsiteURL:     "http://example.com",
 		Port:           3000,
-		NodeLocations:  []string{"foo", "bar"},
+		NodeLocations:  "foo,bar",
 		Timeout:        11,
 		PingURL:        "http://example.com/ping",
 		Confirmation:   1,
@@ -150,13 +153,14 @@ func TestTests_All(t *testing.T) {
 	assert.Len(tests, 2)
 
 	expectedTest := &Test{
-		TestID:      100,
-		Paused:      false,
-		TestType:    "HTTP",
-		WebsiteName: "www 1",
-		ContactID:   1,
-		Status:      "Up",
-		Uptime:      100,
+		TestID:        100,
+		Paused:        false,
+		TestType:      "HTTP",
+		WebsiteName:   "www 1",
+		ContactID:     1,
+		Status:        "Up",
+		Uptime:        100,
+		NodeLocations: "foo,bar",
 	}
 	assert.Equal(expectedTest, tests[0])
 
@@ -168,6 +172,7 @@ func TestTests_All(t *testing.T) {
 		ContactID:   2,
 		Status:      "Down",
 		Uptime:      0,
+		NodeLocations: "foo",
 	}
 	assert.Equal(expectedTest, tests[1])
 }
@@ -300,6 +305,7 @@ func TestTests_Detail_OK(t *testing.T) {
 	assert.Equal(test.WebsiteHost, "Various")
 	assert.Equal(test.FindString, "")
 	assert.Equal(test.DoNotFind, false)
+	assert.Equal(test.NodeLocations, "foo,bar")
 }
 
 type fakeAPIClient struct {


### PR DESCRIPTION
Related to https://github.com/terraform-providers/terraform-provider-statuscake/pull/14

Current Terraform cannot create statusCake Tests with test locations. Updating upstream Terraform support to create/update Statuscake tests with NodeLocations.

Adding node_locations to include NodeLocations option to Statuscake API.

StatusCake API receives string type input to create or update tests but it has a []string type NodeLocations response. A []string to string convention is added to solve this issue.