### PR TITLE
Switch tag & location handling back to lists

### DIFF
--- a/cmd/statuscake/main.go
+++ b/cmd/statuscake/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/DreamItGetIT/statuscake"
+	"strings"
 )
 
 var log *logpkg.Logger
@@ -67,7 +68,7 @@ func cmdList(c *statuscake.Client, args ...string) error {
 		fmt.Printf("  Paused: %s\n", paused)
 		fmt.Printf("  ContactID: %d\n", t.ContactID)
 		fmt.Printf("  Uptime: %f\n", t.Uptime)
-		fmt.Printf("  NodeLocations: %s\n", t.NodeLocations)
+		fmt.Printf("  NodeLocations: %s\n", strings.Join(t.NodeLocations,","))
 	}
 
 	return nil
@@ -104,7 +105,7 @@ func cmdDetail(c *statuscake.Client, args ...string) error {
 	fmt.Printf("  Paused: %s\n", paused)
 	fmt.Printf("  ContactID: %d\n", t.ContactID)
 	fmt.Printf("  Uptime: %f\n", t.Uptime)
-	fmt.Printf("  NodeLocations: %s\n", t.NodeLocations)
+	fmt.Printf("  NodeLocations: %s\n", strings.Join(t.NodeLocations,", "))
 
 	return nil
 }
@@ -145,12 +146,19 @@ func askInt(name string) int {
 }
 
 func cmdCreate(c *statuscake.Client, args ...string) error {
+	websiteName := askString("WebsiteName")
+	websiteURL :=     askString("WebsiteURL")
+	testType :=       askString("TestType")
+	checkRate := askInt("CheckRate")
+	nodeLocationsString := askString("NodeLocations (comma separated list)")
+	nodeLocations := strings.Split(nodeLocationsString, ",")
+
 	t := &statuscake.Test{
-		WebsiteName:    askString("WebsiteName"),
-		WebsiteURL:     askString("WebsiteURL"),
-		TestType:       askString("TestType"),
-		CheckRate:      askInt("CheckRate"),
-		NodeLocations:  askString("NodeLocations"),
+		WebsiteName:    websiteName,
+		WebsiteURL:     websiteURL,
+		TestType:       testType,
+		CheckRate:      checkRate,
+		NodeLocations:  nodeLocations,
 	}
 
 	t2, err := c.Tests().Update(t)
@@ -184,7 +192,8 @@ func cmdUpdate(c *statuscake.Client, args ...string) error {
 	t.WebsiteURL = askString(fmt.Sprintf("WebsiteURL [%s]", t.WebsiteURL))
 	t.TestType = askString(fmt.Sprintf("TestType [%s]", t.TestType))
 	t.CheckRate = askInt(fmt.Sprintf("CheckRate [%d]", t.CheckRate))
-	t.NodeLocations = askString(fmt.Sprintf("NodeLocations [%s]", t.NodeLocations))
+	nodeLocationsString := askString("NodeLocations (comma separated list)")
+	t.NodeLocations = strings.Split(nodeLocationsString, ",")
 
 	t2, err := c.Tests().Update(t)
 	if err != nil {

--- a/fixtures/tests_all_ok.json
+++ b/fixtures/tests_all_ok.json
@@ -8,7 +8,7 @@
       "ContactID": 1,
       "Status": "Up",
       "Uptime": 100,
-      "NodeLocations": "foo,bar"
+      "NodeLocations": ["foo", "bar"]
   },
   {
       "TestID": 101,
@@ -19,6 +19,6 @@
       "ContactID": 2,
       "Status": "Down",
       "Uptime": 0,
-      "NodeLocations": "foo"
+      "NodeLocations": ["foo"]
   }
 ]

--- a/responses.go
+++ b/responses.go
@@ -74,7 +74,7 @@ func (d *detailResponse) test() *Test {
 		LogoImage:      d.LogoImage,
 		Confirmation:   d.Confirmation,
 		WebsiteHost:    d.WebsiteHost,
-		NodeLocations:  strings.Join(d.NodeLocations, ","),
+		NodeLocations:  d.NodeLocations,
 		FindString:     d.FindString,
 		DoNotFind:      d.DoNotFind,
 		Port:           d.Port,

--- a/tests.go
+++ b/tests.go
@@ -94,7 +94,7 @@ type Test struct {
 	TriggerRate int `json:"TriggerRate" querystring:"TriggerRate"`
 
 	// Tags should be seperated by a comma - no spacing between tags (this,is,a set,of,tags)
-	TestTags string `json:"TestTags" querystring:"TestTags"`
+	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`

--- a/tests.go
+++ b/tests.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
-	"regexp"
 )
 
 const queryStringTag = "querystring"
@@ -44,7 +43,7 @@ type Test struct {
 	Uptime float64 `json:"Uptime"`
 
 	// Any test locations seperated by a comma (using the Node Location IDs)
-	NodeLocations string `json:"NodeLocations" querystring:"NodeLocations"`
+	NodeLocations []string `json:"NodeLocations" querystring:"NodeLocations"`
 
 	// Timeout in an int form representing seconds.
 	Timeout int `json:"Timeout" querystring:"Timeout"`
@@ -167,17 +166,6 @@ func (t *Test) Validate() error {
 	var jsonVerifiable map[string]interface{}
 	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
 		e["CustomHeader"] = "must be provided as json string"
-	}
-
-	match, err := regexp.MatchString("^([0-9A-Za-z]*[,][[:space:]]*)*[0-9A-Za-z]+$", t.NodeLocations)
-
-	if err != nil {
-		fmt.Printf("There is a problem with regexp. This is an upstream problem.\n")
-		return nil
-	}
-
-	if match != true {
-		e["NodeLocations"] = "must be test locastion IDs separated by a comma"
 	}
 
 	if len(e) > 0 {

--- a/tests_test.go
+++ b/tests_test.go
@@ -28,7 +28,6 @@ func TestTest_Validate(t *testing.T) {
 		CustomHeader:  "here be dragons",
 		WebsiteName:   "",
 		WebsiteURL:    "",
-		NodeLocations: "foo.bar",
 	}
 
 	err := test.Validate()
@@ -46,7 +45,6 @@ func TestTest_Validate(t *testing.T) {
 	assert.Contains(message, "RealBrowser must be 0 or 1")
 	assert.Contains(message, "TriggerRate must be between 0 and 59")
 	assert.Contains(message, "CustomHeader must be provided as json string")
-	assert.Contains(message, "NodeLocations must be test locastion IDs separated by a comma")
 
 	test.Timeout = 10
 	test.Confirmation = 2
@@ -59,7 +57,7 @@ func TestTest_Validate(t *testing.T) {
 	test.WebsiteName = "Foo"
 	test.WebsiteURL = "http://example.com"
 	test.CustomHeader = `{"test": 15}`
-	test.NodeLocations = "foo,bar"
+	test.NodeLocations = []string{"foo", "bar"}
 
 	err = test.Validate()
 	assert.Nil(err)
@@ -75,7 +73,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		CustomHeader:   `{"some":{"json": ["value"]}}`,
 		WebsiteURL:     "http://example.com",
 		Port:           3000,
-		NodeLocations:  "foo,bar",
+		NodeLocations:  []string{"foo", "bar"},
 		Timeout:        11,
 		PingURL:        "http://example.com/ping",
 		Confirmation:   1,
@@ -160,7 +158,7 @@ func TestTests_All(t *testing.T) {
 		ContactID:     1,
 		Status:        "Up",
 		Uptime:        100,
-		NodeLocations: "foo,bar",
+		NodeLocations: []string{"foo", "bar"},
 	}
 	assert.Equal(expectedTest, tests[0])
 
@@ -172,7 +170,7 @@ func TestTests_All(t *testing.T) {
 		ContactID:   2,
 		Status:      "Down",
 		Uptime:      0,
-		NodeLocations: "foo",
+		NodeLocations: []string{"foo"},
 	}
 	assert.Equal(expectedTest, tests[1])
 }
@@ -305,7 +303,7 @@ func TestTests_Detail_OK(t *testing.T) {
 	assert.Equal(test.WebsiteHost, "Various")
 	assert.Equal(test.FindString, "")
 	assert.Equal(test.DoNotFind, false)
-	assert.Equal(test.NodeLocations, "foo,bar")
+	assert.Equal(test.NodeLocations, []string{"foo", "bar"})
 }
 
 type fakeAPIClient struct {

--- a/tests_test.go
+++ b/tests_test.go
@@ -91,7 +91,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		TestType:       "HTTP",
 		RealBrowser:    1,
 		TriggerRate:    50,
-		TestTags:       "tag1,tag2",
+		TestTags:       []string{"tag1", "tag2"},
 		StatusCodes:    "500",
 		FollowRedirect: false,
 	}


### PR DESCRIPTION
This implements https://github.com/DreamItGetIT/statuscake/pull/26 but retains Tags and NodeLocations as proper lists rather than flattening to comma strings.

The comma separated value handling is moved into main.go for user input only.

Closes https://github.com/DreamItGetIT/statuscake/pull/20