### PR TITLE
Add support for Test ContactGroup

### DIFF
--- a/cmd/statuscake/main.go
+++ b/cmd/statuscake/main.go
@@ -66,7 +66,7 @@ func cmdList(c *statuscake.Client, args ...string) error {
 		fmt.Printf("  WebsiteName: %s\n", t.WebsiteName)
 		fmt.Printf("  TestType: %s\n", t.TestType)
 		fmt.Printf("  Paused: %s\n", paused)
-		fmt.Printf("  ContactID: %d\n", t.ContactID)
+		fmt.Printf("  ContactGroup: %s\n", fmt.Sprint(t.ContactGroup))
 		fmt.Printf("  Uptime: %f\n", t.Uptime)
 	}
 
@@ -102,7 +102,7 @@ func cmdDetail(c *statuscake.Client, args ...string) error {
 	fmt.Printf("  PingURL: %s\n", t.PingURL)
 	fmt.Printf("  TestType: %s\n", t.TestType)
 	fmt.Printf("  Paused: %s\n", paused)
-	fmt.Printf("  ContactID: %d\n", t.ContactID)
+	fmt.Printf("  ContactGroup: %s\n", fmt.Sprint(t.ContactGroup))
 	fmt.Printf("  Uptime: %f\n", t.Uptime)
 	fmt.Printf("  NodeLocations: %s\n", fmt.Sprint(t.NodeLocations))
 
@@ -146,18 +146,21 @@ func askInt(name string) int {
 
 func cmdCreate(c *statuscake.Client, args ...string) error {
 	websiteName := askString("WebsiteName")
-	websiteURL :=     askString("WebsiteURL")
-	testType :=       askString("TestType")
+	websiteURL := askString("WebsiteURL")
+	testType := askString("TestType")
 	checkRate := askInt("CheckRate")
+	contactGroupString := askString("ContactGroup (comma separated list)")
+	contactGroup := strings.Split(contactGroupString, ",")
 	nodeLocationsString := askString("NodeLocations (comma separated list)")
 	nodeLocations := strings.Split(nodeLocationsString, ",")
 
 	t := &statuscake.Test{
-		WebsiteName:    websiteName,
-		WebsiteURL:     websiteURL,
-		TestType:       testType,
-		CheckRate:      checkRate,
-		NodeLocations:  nodeLocations,
+		WebsiteName:   websiteName,
+		WebsiteURL:    websiteURL,
+		TestType:      testType,
+		CheckRate:     checkRate,
+		NodeLocations: nodeLocations,
+		ContactGroup:  contactGroup,
 	}
 
 	t2, err := c.Tests().Update(t)
@@ -191,6 +194,8 @@ func cmdUpdate(c *statuscake.Client, args ...string) error {
 	t.WebsiteURL = askString(fmt.Sprintf("WebsiteURL [%s]", t.WebsiteURL))
 	t.TestType = askString(fmt.Sprintf("TestType [%s]", t.TestType))
 	t.CheckRate = askInt(fmt.Sprintf("CheckRate [%d]", t.CheckRate))
+	contactGroupString := askString("ContactGroup (comma separated list)")
+	t.ContactGroup = strings.Split(contactGroupString, ",")
 	nodeLocationsString := askString("NodeLocations (comma separated list)")
 	t.NodeLocations = strings.Split(nodeLocationsString, ",")
 

--- a/cmd/statuscake/main.go
+++ b/cmd/statuscake/main.go
@@ -68,7 +68,6 @@ func cmdList(c *statuscake.Client, args ...string) error {
 		fmt.Printf("  Paused: %s\n", paused)
 		fmt.Printf("  ContactID: %d\n", t.ContactID)
 		fmt.Printf("  Uptime: %f\n", t.Uptime)
-		fmt.Printf("  NodeLocations: %s\n", strings.Join(t.NodeLocations,","))
 	}
 
 	return nil
@@ -105,7 +104,7 @@ func cmdDetail(c *statuscake.Client, args ...string) error {
 	fmt.Printf("  Paused: %s\n", paused)
 	fmt.Printf("  ContactID: %d\n", t.ContactID)
 	fmt.Printf("  Uptime: %f\n", t.Uptime)
-	fmt.Printf("  NodeLocations: %s\n", strings.Join(t.NodeLocations,", "))
+	fmt.Printf("  NodeLocations: %s\n", fmt.Sprint(t.NodeLocations))
 
 	return nil
 }

--- a/cmd/statuscake/main.go
+++ b/cmd/statuscake/main.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/DreamItGetIT/statuscake"
+	"strings"
 )
 
 var log *logpkg.Logger
@@ -67,7 +68,7 @@ func cmdList(c *statuscake.Client, args ...string) error {
 		fmt.Printf("  Paused: %s\n", paused)
 		fmt.Printf("  ContactID: %d\n", t.ContactID)
 		fmt.Printf("  Uptime: %f\n", t.Uptime)
-		fmt.Printf("  NodeLocations: %s\n", t.NodeLocations)
+		fmt.Printf("  NodeLocations: %s\n", strings.Join(t.NodeLocations,","))
 	}
 
 	return nil
@@ -104,7 +105,7 @@ func cmdDetail(c *statuscake.Client, args ...string) error {
 	fmt.Printf("  Paused: %s\n", paused)
 	fmt.Printf("  ContactID: %d\n", t.ContactID)
 	fmt.Printf("  Uptime: %f\n", t.Uptime)
-	fmt.Printf("  NodeLocations: %s\n", t.NodeLocations)
+	fmt.Printf("  NodeLocations: %s\n", strings.Join(t.NodeLocations,", "))
 
 	return nil
 }
@@ -145,12 +146,19 @@ func askInt(name string) int {
 }
 
 func cmdCreate(c *statuscake.Client, args ...string) error {
+	websiteName := askString("WebsiteName")
+	websiteURL :=     askString("WebsiteURL")
+	testType :=       askString("TestType")
+	checkRate := askInt("CheckRate")
+	nodeLocationsString := askString("NodeLocations (comma separated list)")
+	nodeLocations := strings.Split(nodeLocationsString, ",")
+
 	t := &statuscake.Test{
-		WebsiteName:    askString("WebsiteName"),
-		WebsiteURL:     askString("WebsiteURL"),
-		TestType:       askString("TestType"),
-		CheckRate:      askInt("CheckRate"),
-		NodeLocations:  askString("NodeLocations"),
+		WebsiteName:    websiteName,
+		WebsiteURL:     websiteURL,
+		TestType:       testType,
+		CheckRate:      checkRate,
+		NodeLocations:  nodeLocations,
 	}
 
 	t2, err := c.Tests().Update(t)
@@ -184,7 +192,8 @@ func cmdUpdate(c *statuscake.Client, args ...string) error {
 	t.WebsiteURL = askString(fmt.Sprintf("WebsiteURL [%s]", t.WebsiteURL))
 	t.TestType = askString(fmt.Sprintf("TestType [%s]", t.TestType))
 	t.CheckRate = askInt(fmt.Sprintf("CheckRate [%d]", t.CheckRate))
-	t.NodeLocations = askString(fmt.Sprintf("NodeLocations [%s]", t.NodeLocations))
+	nodeLocationsString := askString("NodeLocations (comma separated list)")
+	t.NodeLocations = strings.Split(nodeLocationsString, ",")
 
 	t2, err := c.Tests().Update(t)
 	if err != nil {

--- a/fixtures/tests_all_ok.json
+++ b/fixtures/tests_all_ok.json
@@ -4,8 +4,7 @@
       "Paused": false,
       "TestType": "HTTP",
       "WebsiteName": "www 1",
-      "ContactGroup": null,
-      "ContactID": 1,
+      "ContactGroup": ["1"],
       "Status": "Up",
       "Uptime": 100,
       "NodeLocations": ["foo", "bar"]
@@ -15,8 +14,7 @@
       "Paused": true,
       "TestType": "HTTP",
       "WebsiteName": "www 2",
-      "ContactGroup": null,
-      "ContactID": 2,
+      "ContactGroup": ["2"],
       "Status": "Down",
       "Uptime": 0,
       "NodeLocations": ["foo"]

--- a/fixtures/tests_all_ok.json
+++ b/fixtures/tests_all_ok.json
@@ -8,7 +8,7 @@
       "ContactID": 1,
       "Status": "Up",
       "Uptime": 100,
-      "NodeLocations": "foo,bar"
+      "NodeLocations": ["foo", "bar"]
   },
   {
       "TestID": 101,
@@ -19,6 +19,6 @@
       "ContactID": 2,
       "Status": "Down",
       "Uptime": 0,
-      "NodeLocations": "foo"
+      "NodeLocations": ["foo"]
   }
 ]

--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -5,7 +5,13 @@
   "WebsiteName": "NL",
   "CustomHeader": "{\"some\":{\"json\": [\"value\"]}}",
   "UserAgent": "product/version (comment)",
-  "ContactGroup": "StatusCake Alerts",
+  "ContactGroups": [
+    {
+    "ID": 536,
+    "Name": "Dummy ContactGroup",
+    "Email": "github-dreamitgetit-statuscake@maildrop.cc"
+    }
+  ],
   "ContactID": 536,
   "Status": "Up",
   "Uptime": 0,

--- a/responses.go
+++ b/responses.go
@@ -1,6 +1,7 @@
 package statuscake
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -21,43 +22,55 @@ type deleteResponse struct {
 	Error   string `json:"Error"`
 }
 
+type contactGroupDetailResponse struct {
+	ID    int    `json:"ID"`
+	Name  string `json:"Name"`
+	Email string `json:"Email"`
+}
+
 type detailResponse struct {
-	Method          string   `json:"Method"`
-	TestID          int      `json:"TestID"`
-	TestType        string   `json:"TestType"`
-	Paused          bool     `json:"Paused"`
-	WebsiteName     string   `json:"WebsiteName"`
-	URI             string   `json:"URI"`
-	ContactID       int      `json:"ContactID"`
-	Status          string   `json:"Status"`
-	Uptime          float64  `json:"Uptime"`
-	CustomHeader    string   `json:"CustomHeader"`
-	UserAgent       string   `json:"UserAgent"`
-	CheckRate       int      `json:"CheckRate"`
-	Timeout         int      `json:"Timeout"`
-	LogoImage       string   `json:"LogoImage"`
-	Confirmation    int      `json:"Confirmation,string"`
-	WebsiteHost     string   `json:"WebsiteHost"`
-	NodeLocations   []string `json:"NodeLocations"`
-	FindString      string   `json:"FindString"`
-	DoNotFind       bool     `json:"DoNotFind"`
-	LastTested      string   `json:"LastTested"`
-	NextLocation    string   `json:"NextLocation"`
-	Port            int      `json:"Port"`
-	Processing      bool     `json:"Processing"`
-	ProcessingState string   `json:"ProcessingState"`
-	ProcessingOn    string   `json:"ProcessingOn"`
-	DownTimes       int      `json:"DownTimes,string"`
-	Sensitive       bool     `json:"Sensitive"`
-	TriggerRate     int      `json:"TriggerRate,string"`
-	UseJar          int      `json:"UseJar"`
-	PostRaw         string   `json:"PostRaw"`
-	FinalEndpoint   string   `json:"FinalEndpoint"`
-	FollowRedirect  bool     `json:"FollowRedirect"`
-	StatusCodes     []string `json:"StatusCodes"`
+	Method          string                       `json:"Method"`
+	TestID          int                          `json:"TestID"`
+	TestType        string                       `json:"TestType"`
+	Paused          bool                         `json:"Paused"`
+	WebsiteName     string                       `json:"WebsiteName"`
+	URI             string                       `json:"URI"`
+	ContactID       int                          `json:"ContactID"`
+	ContactGroups   []contactGroupDetailResponse `json:"ContactGroups"`
+	Status          string                       `json:"Status"`
+	Uptime          float64                      `json:"Uptime"`
+	CustomHeader    string                       `json:"CustomHeader"`
+	UserAgent       string                       `json:"UserAgent"`
+	CheckRate       int                          `json:"CheckRate"`
+	Timeout         int                          `json:"Timeout"`
+	LogoImage       string                       `json:"LogoImage"`
+	Confirmation    int                          `json:"Confirmation,string"`
+	WebsiteHost     string                       `json:"WebsiteHost"`
+	NodeLocations   []string                     `json:"NodeLocations"`
+	FindString      string                       `json:"FindString"`
+	DoNotFind       bool                         `json:"DoNotFind"`
+	LastTested      string                       `json:"LastTested"`
+	NextLocation    string                       `json:"NextLocation"`
+	Port            int                          `json:"Port"`
+	Processing      bool                         `json:"Processing"`
+	ProcessingState string                       `json:"ProcessingState"`
+	ProcessingOn    string                       `json:"ProcessingOn"`
+	DownTimes       int                          `json:"DownTimes,string"`
+	Sensitive       bool                         `json:"Sensitive"`
+	TriggerRate     int                          `json:"TriggerRate,string"`
+	UseJar          int                          `json:"UseJar"`
+	PostRaw         string                       `json:"PostRaw"`
+	FinalEndpoint   string                       `json:"FinalEndpoint"`
+	FollowRedirect  bool                         `json:"FollowRedirect"`
+	StatusCodes     []string                     `json:"StatusCodes"`
 }
 
 func (d *detailResponse) test() *Test {
+	contactGroupIds := make([]string, len(d.ContactGroups))
+	for i, v := range d.ContactGroups {
+		contactGroupIds[i] = strconv.Itoa(v.ID)
+	}
+
 	return &Test{
 		TestID:         d.TestID,
 		TestType:       d.TestType,
@@ -67,6 +80,7 @@ func (d *detailResponse) test() *Test {
 		CustomHeader:   d.CustomHeader,
 		UserAgent:      d.UserAgent,
 		ContactID:      d.ContactID,
+		ContactGroup:   contactGroupIds,
 		Status:         d.Status,
 		Uptime:         d.Uptime,
 		CheckRate:      d.CheckRate,

--- a/responses.go
+++ b/responses.go
@@ -74,7 +74,7 @@ func (d *detailResponse) test() *Test {
 		LogoImage:      d.LogoImage,
 		Confirmation:   d.Confirmation,
 		WebsiteHost:    d.WebsiteHost,
-		NodeLocations:  strings.Join(d.NodeLocations, ","),
+		NodeLocations:  d.NodeLocations,
 		FindString:     d.FindString,
 		DoNotFind:      d.DoNotFind,
 		Port:           d.Port,

--- a/tests.go
+++ b/tests.go
@@ -54,7 +54,7 @@ type Test struct {
 	// A URL to ping if a site goes down.
 	PingURL string `json:"PingURL" querystring:"PingURL"`
 
-	Confirmation int `json:"Confirmationi,string" querystring:"Confirmation"`
+	Confirmation int `json:"Confirmation,string" querystring:"Confirmation"`
 
 	// The number of seconds between checks.
 	CheckRate int `json:"CheckRate" querystring:"CheckRate"`

--- a/tests.go
+++ b/tests.go
@@ -94,7 +94,7 @@ type Test struct {
 	TriggerRate int `json:"TriggerRate" querystring:"TriggerRate"`
 
 	// Tags should be seperated by a comma - no spacing between tags (this,is,a set,of,tags)
-	TestTags string `json:"TestTags" querystring:"TestTags"`
+	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
 	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`

--- a/tests.go
+++ b/tests.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
-	"regexp"
 )
 
 const queryStringTag = "querystring"
@@ -44,7 +43,7 @@ type Test struct {
 	Uptime float64 `json:"Uptime"`
 
 	// Any test locations seperated by a comma (using the Node Location IDs)
-	NodeLocations string `json:"NodeLocations" querystring:"NodeLocations"`
+	NodeLocations []string `json:"NodeLocations" querystring:"NodeLocations"`
 
 	// Timeout in an int form representing seconds.
 	Timeout int `json:"Timeout" querystring:"Timeout"`
@@ -167,17 +166,6 @@ func (t *Test) Validate() error {
 	var jsonVerifiable map[string]interface{}
 	if json.Unmarshal([]byte(t.CustomHeader), &jsonVerifiable) != nil {
 		e["CustomHeader"] = "must be provided as json string"
-	}
-
-	match, err := regexp.MatchString("^([0-9A-Za-z]*[,][[:space:]]*)*[0-9A-Za-z]+$", t.NodeLocations)
-
-	if err != nil {
-		fmt.Printf("There is a problem with regexp. This is an upstream problem.\n")
-		return nil
-	}
-
-	if match != true {
-		e["NodeLocations"] = "must be test locastion IDs separated by a comma"
 	}
 
 	if len(e) > 0 {

--- a/tests.go
+++ b/tests.go
@@ -12,7 +12,7 @@ const queryStringTag = "querystring"
 
 // Test represents a statuscake Test
 type Test struct {
-	// ThiTestID is an int, use this to get more details about this test. If not provided will insert a new check, else will update
+	// TestID is an int, use this to get more details about this test. If not provided will insert a new check, else will update
 	TestID int `json:"TestID" querystring:"TestID" querystringoptions:"omitempty"`
 
 	// Sent tfalse To Unpause and true To Pause.

--- a/tests.go
+++ b/tests.go
@@ -33,8 +33,11 @@ type Test struct {
 	// A Port to use on TCP Tests
 	Port int `json:"Port" querystring:"Port"`
 
-	// Contact group ID - will return int of contact group used else 0
-	ContactID int `json:"ContactID" querystring:"ContactGroup"`
+	// Contact group ID - deprecated in favor of ContactGroup but still provided in the API detail response
+	ContactID int `json:"ContactID"`
+
+	// Contact group IDs - will return list of ints or empty if not provided
+	ContactGroup []string `json:"ContactGroup" querystring:"ContactGroup"`
 
 	// Current status at last test
 	Status string `json:"Status"`

--- a/tests_test.go
+++ b/tests_test.go
@@ -17,17 +17,17 @@ func TestTest_Validate(t *testing.T) {
 	require := require.New(t)
 
 	test := &Test{
-		Timeout:       200,
-		Confirmation:  100,
-		Public:        200,
-		Virus:         200,
-		TestType:      "FTP",
-		RealBrowser:   100,
-		TriggerRate:   100,
-		CheckRate:     100000,
-		CustomHeader:  "here be dragons",
-		WebsiteName:   "",
-		WebsiteURL:    "",
+		Timeout:      200,
+		Confirmation: 100,
+		Public:       200,
+		Virus:        200,
+		TestType:     "FTP",
+		RealBrowser:  100,
+		TriggerRate:  100,
+		CheckRate:    100000,
+		CustomHeader: "here be dragons",
+		WebsiteName:  "",
+		WebsiteURL:   "",
 	}
 
 	err := test.Validate()
@@ -104,8 +104,8 @@ func TestTest_ToURLValues(t *testing.T) {
 		"NodeLocations":  {"foo,bar"},
 		"Timeout":        {"11"},
 		"PingURL":        {"http://example.com/ping"},
+		"ContactGroup":   {""},
 		"Confirmation":   {"1"},
-		"ContactGroup":   {"0"}, //defaults to 0 when not provided
 		"CheckRate":      {"500"},
 		"BasicUser":      {"myuser"},
 		"BasicPass":      {"mypass"},
@@ -155,7 +155,7 @@ func TestTests_All(t *testing.T) {
 		Paused:        false,
 		TestType:      "HTTP",
 		WebsiteName:   "www 1",
-		ContactID:     1,
+		ContactGroup:  []string{"1"},
 		Status:        "Up",
 		Uptime:        100,
 		NodeLocations: []string{"foo", "bar"},
@@ -163,13 +163,13 @@ func TestTests_All(t *testing.T) {
 	assert.Equal(expectedTest, tests[0])
 
 	expectedTest = &Test{
-		TestID:      101,
-		Paused:      true,
-		TestType:    "HTTP",
-		WebsiteName: "www 2",
-		ContactID:   2,
-		Status:      "Down",
-		Uptime:      0,
+		TestID:        101,
+		Paused:        true,
+		TestType:      "HTTP",
+		WebsiteName:   "www 2",
+		ContactGroup:  []string{"2"},
+		Status:        "Down",
+		Uptime:        0,
 		NodeLocations: []string{"foo"},
 	}
 	assert.Equal(expectedTest, tests[1])
@@ -294,7 +294,7 @@ func TestTests_Detail_OK(t *testing.T) {
 	assert.Equal(test.WebsiteName, "NL")
 	assert.Equal(test.CustomHeader, `{"some":{"json": ["value"]}}`)
 	assert.Equal(test.UserAgent, "product/version (comment)")
-	assert.Equal(test.ContactID, 536)
+	assert.Equal(test.ContactGroup, []string{"536"})
 	assert.Equal(test.Status, "Up")
 	assert.Equal(test.Uptime, 0.0)
 	assert.Equal(test.CheckRate, 60)

--- a/tests_test.go
+++ b/tests_test.go
@@ -28,7 +28,6 @@ func TestTest_Validate(t *testing.T) {
 		CustomHeader:  "here be dragons",
 		WebsiteName:   "",
 		WebsiteURL:    "",
-		NodeLocations: "foo.bar",
 	}
 
 	err := test.Validate()
@@ -46,7 +45,6 @@ func TestTest_Validate(t *testing.T) {
 	assert.Contains(message, "RealBrowser must be 0 or 1")
 	assert.Contains(message, "TriggerRate must be between 0 and 59")
 	assert.Contains(message, "CustomHeader must be provided as json string")
-	assert.Contains(message, "NodeLocations must be test locastion IDs separated by a comma")
 
 	test.Timeout = 10
 	test.Confirmation = 2
@@ -59,7 +57,7 @@ func TestTest_Validate(t *testing.T) {
 	test.WebsiteName = "Foo"
 	test.WebsiteURL = "http://example.com"
 	test.CustomHeader = `{"test": 15}`
-	test.NodeLocations = "foo,bar"
+	test.NodeLocations = []string{"foo", "bar"}
 
 	err = test.Validate()
 	assert.Nil(err)
@@ -75,7 +73,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		CustomHeader:   `{"some":{"json": ["value"]}}`,
 		WebsiteURL:     "http://example.com",
 		Port:           3000,
-		NodeLocations:  "foo,bar",
+		NodeLocations:  []string{"foo", "bar"},
 		Timeout:        11,
 		PingURL:        "http://example.com/ping",
 		Confirmation:   1,
@@ -160,7 +158,7 @@ func TestTests_All(t *testing.T) {
 		ContactID:     1,
 		Status:        "Up",
 		Uptime:        100,
-		NodeLocations: "foo,bar",
+		NodeLocations: []string{"foo", "bar"},
 	}
 	assert.Equal(expectedTest, tests[0])
 
@@ -172,7 +170,7 @@ func TestTests_All(t *testing.T) {
 		ContactID:   2,
 		Status:      "Down",
 		Uptime:      0,
-		NodeLocations: "foo",
+		NodeLocations: []string{"foo"},
 	}
 	assert.Equal(expectedTest, tests[1])
 }
@@ -305,7 +303,7 @@ func TestTests_Detail_OK(t *testing.T) {
 	assert.Equal(test.WebsiteHost, "Various")
 	assert.Equal(test.FindString, "")
 	assert.Equal(test.DoNotFind, false)
-	assert.Equal(test.NodeLocations, "foo,bar")
+	assert.Equal(test.NodeLocations, []string{"foo", "bar"})
 }
 
 type fakeAPIClient struct {

--- a/tests_test.go
+++ b/tests_test.go
@@ -91,7 +91,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		TestType:       "HTTP",
 		RealBrowser:    1,
 		TriggerRate:    50,
-		TestTags:       "tag1,tag2",
+		TestTags:       []string{"tag1", "tag2"},
 		StatusCodes:    "500",
 		FollowRedirect: false,
 	}


### PR DESCRIPTION
This essentially deprecates ContactID in favor of ContactGroup which is now the main field in the statuscake API.

We still parse ContactID from the detail response for backward compatibility but only the ContactGroup field is used for create/update.

NOTE: This is based on https://github.com/DreamItGetIT/statuscake/pull/27 since that includes fixes that allow all the main.go methods to work for testing.

Will rebase after that PR is merged.