### PR TITLE
Fixing WebsiteHost for StatusCake client used in Terraform provider. …

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -75,7 +75,7 @@ type Test struct {
 	Branding int `json:"Branding" querystring:"Branding"`
 
 	// Used internally by the statuscake API
-	WebsiteHost string `json:"WebsiteHost"`
+	WebsiteHost string `json:"WebsiteHost" querystring:"WebsiteHost"`
 
 	// Enable virus checking or not. 1 to enable
 	Virus int `json:"Virus" querystring:"Virus"`


### PR DESCRIPTION
…The querystring tag was missing and parameter was not being used in the update function
