### PR TITLE
Add SSL validation for uptime tests

### DIFF
--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -34,5 +34,6 @@
   "UseJar": 0,
   "PostRaw": "",
   "FinalEndpoint": "",
+  "EnableSSLWarning": false,
   "FollowRedirect": false
 }

--- a/responses.go
+++ b/responses.go
@@ -61,6 +61,7 @@ type detailResponse struct {
 	UseJar          int                          `json:"UseJar"`
 	PostRaw         string                       `json:"PostRaw"`
 	FinalEndpoint   string                       `json:"FinalEndpoint"`
+	EnableSSLWarning  bool                       `json:"EnableSSLWarning"`
 	FollowRedirect  bool                         `json:"FollowRedirect"`
 	StatusCodes     []string                     `json:"StatusCodes"`
 }
@@ -96,6 +97,7 @@ func (d *detailResponse) test() *Test {
 		UseJar:         d.UseJar,
 		PostRaw:        d.PostRaw,
 		FinalEndpoint:  d.FinalEndpoint,
+		EnableSSLAlert: d.EnableSSLWarning,
 		FollowRedirect: d.FollowRedirect,
 		StatusCodes:    strings.Join(d.StatusCodes[:], ","),
 	}

--- a/tests.go
+++ b/tests.go
@@ -110,6 +110,9 @@ type Test struct {
 	// Use to specify the expected Final URL in the testing process
 	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
 
+	// Use to enable SSL validation
+	EnableSSLAlert bool `json:"EnableSSLAlert" querystring:"EnableSSLAlert"`
+
 	// Use to specify whether redirects should be followed
 	FollowRedirect bool `json:"FollowRedirect" querystring:"FollowRedirect"`
 }

--- a/tests_test.go
+++ b/tests_test.go
@@ -96,6 +96,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		TriggerRate:    50,
 		TestTags:       []string{"tag1", "tag2"},
 		StatusCodes:    "500",
+		EnableSSLAlert: false,
 		FollowRedirect: false,
 	}
 
@@ -129,6 +130,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		"UseJar":         {"0"},
 		"PostRaw":        {""},
 		"FinalEndpoint":  {""},
+		"EnableSSLAlert": {"0"},
 		"FollowRedirect": {"0"},
 	}
 


### PR DESCRIPTION
Handles SSL validation for uptime tests (unrelated to dedicated SSL tests - #32).

Motivation:  terraform-providers/terraform-provider-statuscake#16

I've tried to be as consistent as possible with [StatusCake API](https://www.statuscake.com/api/) docs in terms of naming, but I'm happy to change things according to your requirements.

Note that API expects the `EnableSSLAlert` property for create and update requests, but returns the `EnableSSLWarning` property for get requests even though ultimately it's the same property. I'm not sure why.

Please let me know if there are changes required in order for this feature to be merged.