### PR TITLE
Allow default value for Create Test

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -99,7 +99,7 @@ type Test struct {
 	TestTags []string `json:"TestTags" querystring:"TestTags"`
 
 	// Comma Seperated List of StatusCodes to Trigger Error on (on Update will replace, so send full list each time)
-	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes"`
+	StatusCodes string `json:"StatusCodes" querystring:"StatusCodes" querystringoptions:"omitempty"`
 
 	// Set to 1 to enable the Cookie Jar. Required for some redirects.
 	UseJar int `json:"UseJar" querystring:"UseJar"`

--- a/tests_test.go
+++ b/tests_test.go
@@ -140,6 +140,11 @@ func TestTest_ToURLValues(t *testing.T) {
 	delete(expected, "TestID")
 
 	assert.Equal(expected.Encode(), test.ToURLValues().Encode())
+
+	test.StatusCodes = ""
+	delete(expected, "StatusCodes")
+
+	assert.Equal(expected.Encode(), test.ToURLValues().Encode())
 }
 
 func TestTests_All(t *testing.T) {
@@ -179,7 +184,7 @@ func TestTests_All(t *testing.T) {
 		Status:        "Down",
 		Uptime:        0,
 		NodeLocations: []string{"foo"},
-		TestTags:  	   []string{"test1", "test2"},
+		TestTags:      []string{"test1", "test2"},
 	}
 	assert.Equal(expectedTest, tests[1])
 }
@@ -212,7 +217,7 @@ func TestTests_AllWithFilter(t *testing.T) {
 		Status:        "Down",
 		Uptime:        0,
 		NodeLocations: []string{"foo"},
-		TestTags:  	   []string{"test1", "test2"},
+		TestTags:      []string{"test1", "test2"},
 	}
 	assert.Equal(expectedTest, tests[0])
 }


### PR DESCRIPTION
The StatusCake API will apply a default value to StatusCodes if the parameter is not present but if it is present with no value no status codes are set. This is not desired because a 500 should be detected as the site being down.

This change dose not pass StatusCode if the value is an empty string.

It helps fix terraform-providers/terraform-provider-statuscake#43