### PR TITLE
ssl: Handle number- and string-type checkrate values in upstream responses

### DIFF
--- a/ssl.go
+++ b/ssl.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"strings"
 	"strconv"
-	
+	"strings"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -73,16 +73,15 @@ type updateSsl struct {
 	AlertMixed     bool   `url:"alert_mixed"    json:"alert_mixed"`
 }
 
-
 type sslUpdateResponse struct {
-	Success bool   `json:"Success"`
+	Success bool        `json:"Success"`
 	Message interface{} `json:"Message"`
 }
 
 type sslCreateResponse struct {
-	Success bool   `json:"Success"`
+	Success bool        `json:"Success"`
 	Message interface{} `json:"Message"`
-	Input createSsl `json:"Input"`
+	Input   createSsl   `json:"Input"`
 }
 
 //Ssls represent the actions done wit the API
@@ -116,31 +115,31 @@ func (tt *ssls) completeSsl(s *PartialSsl) (*Ssl, error) {
 	if err != nil {
 		return nil, err
 	}
-	(*full).ContactGroups = strings.Split((*s).ContactGroupsC,",")
+	(*full).ContactGroups = strings.Split((*s).ContactGroupsC, ",")
 	return full, nil
 }
 
 //Partial return a PartialSsl corresponding to the Ssl
-func Partial(s *Ssl) (*PartialSsl,error) {
-	if s==nil {
-		return nil,fmt.Errorf("s is nil")
+func Partial(s *Ssl) (*PartialSsl, error) {
+	if s == nil {
+		return nil, fmt.Errorf("s is nil")
 	}
-	id,err:=strconv.Atoi(s.ID)
-	if(err!=nil){
-		return nil,err
+	id, err := strconv.Atoi(s.ID)
+	if err != nil {
+		return nil, err
 	}
 	return &PartialSsl{
-		ID: id,
-		Domain: s.Domain,
-		Checkrate: strconv.Itoa(s.Checkrate),
+		ID:             id,
+		Domain:         s.Domain,
+		Checkrate:      strconv.Itoa(s.Checkrate),
 		ContactGroupsC: s.ContactGroupsC,
-		AlertReminder: s.AlertReminder,
-		AlertExpiry: s.AlertExpiry,
-		AlertBroken: s.AlertBroken,
-		AlertMixed: s.AlertMixed,
-		AlertAt: s.AlertAt,
-	},nil
-	
+		AlertReminder:  s.AlertReminder,
+		AlertExpiry:    s.AlertExpiry,
+		AlertBroken:    s.AlertBroken,
+		AlertMixed:     s.AlertMixed,
+		AlertAt:        s.AlertAt,
+	}, nil
+
 }
 
 type ssls struct {
@@ -165,15 +164,15 @@ func (tt *ssls) All() ([]*Ssl, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	for ssl := range getResponse {
 		consolidateSsl(getResponse[ssl])
 	}
-	
+
 	return getResponse, err
 }
 
-//Detail return the ssl corresponding to the id 
+//Detail return the ssl corresponding to the id
 func (tt *ssls) Detail(id string) (*Ssl, error) {
 	responses, err := tt.All()
 	if err != nil {
@@ -190,7 +189,7 @@ func (tt *ssls) Detail(id string) (*Ssl, error) {
 func (tt *ssls) Update(s *PartialSsl) (*Ssl, error) {
 	var err error
 	s, err = tt.UpdatePartial(s)
-	if err!= nil {
+	if err != nil {
 		return nil, err
 	}
 	return tt.completeSsl(s)
@@ -199,28 +198,27 @@ func (tt *ssls) Update(s *PartialSsl) (*Ssl, error) {
 //UpdatePartial update the API with s and create one if s.ID=0 then return the corresponding PartialSsl
 func (tt *ssls) UpdatePartial(s *PartialSsl) (*PartialSsl, error) {
 
-	if((*s).ID == 0){
+	if (*s).ID == 0 {
 		return tt.CreatePartial(s)
 	}
 	var v url.Values
 
 	v, _ = query.Values(updateSsl(*s))
-	
+
 	rawResponse, err := tt.client.put("/SSL/Update", v)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating StatusCake Ssl: %s", err.Error())
 	}
-	
+
 	var updateResponse sslUpdateResponse
 	err = json.NewDecoder(rawResponse.Body).Decode(&updateResponse)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if !updateResponse.Success {
 		return nil, fmt.Errorf("%s", updateResponse.Message.(string))
 	}
-
 
 	return s, nil
 }
@@ -239,7 +237,7 @@ func (tt *ssls) Delete(id string) error {
 func (tt *ssls) Create(s *PartialSsl) (*Ssl, error) {
 	var err error
 	s, err = tt.CreatePartial(s)
-	if err!= nil {
+	if err != nil {
 		return nil, err
 	}
 	return tt.completeSsl(s)
@@ -247,10 +245,10 @@ func (tt *ssls) Create(s *PartialSsl) (*Ssl, error) {
 
 //CreatePartial create the ssl whith the data in s and return the PartialSsl created
 func (tt *ssls) CreatePartial(s *PartialSsl) (*PartialSsl, error) {
-	(*s).ID=0
+	(*s).ID = 0
 	var v url.Values
 	v, _ = query.Values(createSsl(*s))
-	
+
 	rawResponse, err := tt.client.put("/SSL/Update", v)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating StatusCake Ssl: %s", err.Error())
@@ -267,7 +265,6 @@ func (tt *ssls) CreatePartial(s *PartialSsl) (*PartialSsl, error) {
 	}
 	*s = PartialSsl(createResponse.Input)
 	(*s).ID = int(createResponse.Message.(float64))
-	
-	return s,nil
-}
 
+	return s, nil
+}

--- a/ssl.go
+++ b/ssl.go
@@ -50,27 +50,75 @@ type PartialSsl struct {
 }
 
 type createSsl struct {
-	ID             int    `url:"id,omitempty"`
-	Domain         string `url:"domain"         json:"domain"`
-	Checkrate      string `url:"checkrate"      json:"checkrate"`
-	ContactGroupsC string `url:"contact_groups" json:"contact_groups"`
-	AlertAt        string `url:"alert_at"       json:"alert_at"`
-	AlertExpiry    bool   `url:"alert_expiry"   json:"alert_expiry"`
-	AlertReminder  bool   `url:"alert_reminder" json:"alert_reminder"`
-	AlertBroken    bool   `url:"alert_broken"   json:"alert_broken"`
-	AlertMixed     bool   `url:"alert_mixed"    json:"alert_mixed"`
+	ID             int              `url:"id,omitempty"`
+	Domain         string           `url:"domain"         json:"domain"`
+	Checkrate      jsonNumberString `url:"checkrate"      json:"checkrate"`
+	ContactGroupsC string           `url:"contact_groups" json:"contact_groups"`
+	AlertAt        string           `url:"alert_at"       json:"alert_at"`
+	AlertExpiry    bool             `url:"alert_expiry"   json:"alert_expiry"`
+	AlertReminder  bool             `url:"alert_reminder" json:"alert_reminder"`
+	AlertBroken    bool             `url:"alert_broken"   json:"alert_broken"`
+	AlertMixed     bool             `url:"alert_mixed"    json:"alert_mixed"`
+}
+
+func (cs *createSsl) fromPartial(p *PartialSsl) {
+	cs.ID = p.ID
+	cs.Domain = p.Domain
+	cs.Checkrate = jsonNumberString(p.Checkrate)
+	cs.ContactGroupsC = p.ContactGroupsC
+	cs.AlertAt = p.AlertAt
+	cs.AlertExpiry = p.AlertExpiry
+	cs.AlertReminder = p.AlertReminder
+	cs.AlertBroken = p.AlertBroken
+	cs.AlertMixed = p.AlertMixed
+}
+
+func (cs *createSsl) toPartial(p *PartialSsl) {
+	p.ID = cs.ID
+	p.Domain = cs.Domain
+	p.Checkrate = string(cs.Checkrate)
+	p.ContactGroupsC = cs.ContactGroupsC
+	p.AlertAt = cs.AlertAt
+	p.AlertExpiry = cs.AlertExpiry
+	p.AlertReminder = cs.AlertReminder
+	p.AlertBroken = cs.AlertBroken
+	p.AlertMixed = cs.AlertMixed
 }
 
 type updateSsl struct {
-	ID             int    `url:"id"`
-	Domain         string `url:"domain"         json:"domain"`
-	Checkrate      string `url:"checkrate"      json:"checkrate"`
-	ContactGroupsC string `url:"contact_groups" json:"contact_groups"`
-	AlertAt        string `url:"alert_at"       json:"alert_at"`
-	AlertExpiry    bool   `url:"alert_expiry"   json:"alert_expiry"`
-	AlertReminder  bool   `url:"alert_reminder" json:"alert_reminder"`
-	AlertBroken    bool   `url:"alert_broken"   json:"alert_broken"`
-	AlertMixed     bool   `url:"alert_mixed"    json:"alert_mixed"`
+	ID             int              `url:"id"`
+	Domain         string           `url:"domain"         json:"domain"`
+	Checkrate      jsonNumberString `url:"checkrate"      json:"checkrate"`
+	ContactGroupsC string           `url:"contact_groups" json:"contact_groups"`
+	AlertAt        string           `url:"alert_at"       json:"alert_at"`
+	AlertExpiry    bool             `url:"alert_expiry"   json:"alert_expiry"`
+	AlertReminder  bool             `url:"alert_reminder" json:"alert_reminder"`
+	AlertBroken    bool             `url:"alert_broken"   json:"alert_broken"`
+	AlertMixed     bool             `url:"alert_mixed"    json:"alert_mixed"`
+}
+
+func (us *updateSsl) fromPartial(p *PartialSsl) {
+	us.ID = p.ID
+	us.Domain = p.Domain
+	us.Checkrate = jsonNumberString(p.Checkrate)
+	us.ContactGroupsC = p.ContactGroupsC
+	us.AlertAt = p.AlertAt
+	us.AlertExpiry = p.AlertExpiry
+	us.AlertReminder = p.AlertReminder
+	us.AlertBroken = p.AlertBroken
+	us.AlertMixed = p.AlertMixed
+}
+
+func (us *updateSsl) toPartial(p *PartialSsl) {
+	p.ID = us.ID
+	p.Domain = us.Domain
+	p.Checkrate = string(us.Checkrate)
+	p.ContactGroupsC = us.ContactGroupsC
+	p.AlertAt = us.AlertAt
+	p.AlertExpiry = us.AlertExpiry
+	p.AlertReminder = us.AlertReminder
+	p.AlertBroken = us.AlertBroken
+	p.AlertMixed = us.AlertMixed
 }
 
 type sslUpdateResponse struct {
@@ -197,13 +245,16 @@ func (tt *ssls) Update(s *PartialSsl) (*Ssl, error) {
 
 //UpdatePartial update the API with s and create one if s.ID=0 then return the corresponding PartialSsl
 func (tt *ssls) UpdatePartial(s *PartialSsl) (*PartialSsl, error) {
-
 	if (*s).ID == 0 {
 		return tt.CreatePartial(s)
 	}
-	var v url.Values
 
-	v, _ = query.Values(updateSsl(*s))
+	var v url.Values
+	{
+		us := updateSsl{}
+		us.fromPartial(s)
+		v, _ = query.Values(us)
+	}
 
 	rawResponse, err := tt.client.put("/SSL/Update", v)
 	if err != nil {
@@ -247,7 +298,11 @@ func (tt *ssls) Create(s *PartialSsl) (*Ssl, error) {
 func (tt *ssls) CreatePartial(s *PartialSsl) (*PartialSsl, error) {
 	(*s).ID = 0
 	var v url.Values
-	v, _ = query.Values(createSsl(*s))
+	{
+		cs := createSsl{}
+		cs.fromPartial(s)
+		v, _ = query.Values(cs)
+	}
 
 	rawResponse, err := tt.client.put("/SSL/Update", v)
 	if err != nil {
@@ -263,7 +318,7 @@ func (tt *ssls) CreatePartial(s *PartialSsl) (*PartialSsl, error) {
 	if !createResponse.Success {
 		return nil, fmt.Errorf("%s", createResponse.Message.(string))
 	}
-	*s = PartialSsl(createResponse.Input)
+	createResponse.Input.toPartial(s)
 	(*s).ID = int(createResponse.Message.(float64))
 
 	return s, nil

--- a/types.go
+++ b/types.go
@@ -1,0 +1,61 @@
+package statuscake
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+type jsonNumberString string
+
+func (v *jsonNumberString) UnmarshalJSON(b []byte) error {
+	if err := v.unmarshalAsInt(b); err == nil {
+		return nil
+	}
+	if err := v.unmarshalAsString(b); err == nil {
+		return nil
+	}
+	return fmt.Errorf("cannot unmarshal value that is neither a number nor a string: %s", truncate(b, 30))
+}
+
+func (v *jsonNumberString) unmarshalAsInt(b []byte) error {
+	if bytes.Equal(b, []byte(`null`)) {
+		return errors.New("cannot unmarshal JSON null to Go int")
+	}
+
+	var vv int
+	if err := json.Unmarshal(b, &vv); err != nil {
+		return err
+	}
+	*v = jsonNumberString(strconv.Itoa(vv))
+	return nil
+}
+
+func (v *jsonNumberString) unmarshalAsString(b []byte) error {
+	var vv string
+	if err := json.Unmarshal(b, &vv); err != nil {
+		return err
+	}
+	*v = jsonNumberString(vv)
+	return nil
+}
+
+const truncateEllipses = "..."
+
+func truncate(b []byte, max int) []byte {
+	lte := len(truncateEllipses)
+	min := lte + 3
+	if max < min {
+		max = min
+	}
+	if len(b) > max {
+		t := make([]byte, max)
+		n := max - lte
+		copy(t, b[0:n])
+		copy(t[n:], truncateEllipses)
+		return t
+	}
+	return b
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,76 @@
+package statuscake
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONNumberStringMarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	b, err := json.Marshal(jsonNumberString("123"))
+
+	assert.Equal(b, []byte(`"123"`))
+	assert.NoError(err)
+}
+
+func TestJSONNumberStringUnmarshal(t *testing.T) {
+	assert := assert.New(t)
+
+	type testCase struct {
+		Input         []byte
+		ExpectedValue jsonNumberString
+		ExpectedError bool
+		ActualValue   jsonNumberString
+		ActualError   error
+	}
+	cases := []testCase{
+		{
+			Input:         []byte(`"123"`),
+			ExpectedValue: jsonNumberString("123"),
+		},
+		{
+			Input:         []byte(`""`),
+			ExpectedValue: jsonNumberString(""),
+		},
+		{
+			Input:         []byte(`123`),
+			ExpectedValue: jsonNumberString("123"),
+		},
+		{
+			Input:         []byte(`null`),
+			ExpectedValue: jsonNumberString(""),
+		},
+		{
+			Input:         []byte(`123.456`),
+			ExpectedError: true,
+		},
+		{
+			Input:         []byte(`["123"]`),
+			ExpectedError: true,
+		},
+	}
+	for i, c := range cases {
+		cases[i].ActualError = json.Unmarshal(c.Input, &cases[i].ActualValue)
+	}
+
+	for _, c := range cases {
+		if c.ExpectedError {
+			assert.Error(c.ActualError)
+			continue
+		}
+		assert.Equal(c.ExpectedValue, c.ActualValue)
+		assert.NoError(c.ActualError)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal([]byte("foo"), truncate([]byte("foo"), 10))
+	assert.Equal([]byte("foo"), truncate([]byte("foo"), 3))
+	assert.Equal([]byte("foo..."), truncate([]byte("foobarbaz"), 6))
+	assert.Equal([]byte("foo..."), truncate([]byte("foobarbaz"), 1))
+}


### PR DESCRIPTION
Fixes #50.

Type adaptations are handled internally.  There is no change to the external API.

I tested with real StatusCake resources and the following program:

``` go
package main

import (
	"fmt"
	"log"
	"os"

	"github.com/DreamItGetIT/statuscake"
)

func init() {
	log.SetFlags(0)
}

func main() {
	c, err := statuscake.New(statuscake.Auth{
		Username: mustGetEnv("STATUSCAKE_USERNAME"),
		Apikey:   mustGetEnv("STATUSCAKE_APIKEY"),
	})
	if err != nil {
		log.Fatal(err)
	}

	s, err := statuscake.NewSsls(c).Create(&statuscake.PartialSsl{
		Domain:         "https://www.google.com",
		Checkrate:      "300",
		ContactGroupsC: "",
		AlertAt:        "2,7,14",
		AlertExpiry:    false,
		AlertReminder:  false,
		AlertBroken:    false,
		AlertMixed:     false,
	})
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("after create: %+v", s)

	u, err := statuscake.Partial(s)
	if err != nil {
		log.Fatal(err)
	}
	u.Checkrate = "600"

	s, err = statuscake.NewSsls(c).Update(u)
	if err != nil {
		log.Fatal(err)
	}
	log.Printf("after update: %+v", s)
}

func mustGetEnv(name string) string {
	v, ok := os.LookupEnv(name)
	if !ok {
		panic(fmt.Sprintf("missing required environment variable: %s", name))
	}
	return v
}
```

Output against `master`:

```
json: cannot unmarshal number into Go struct field createSsl.Input.checkrate of type string
```

(Despite the error, a new 'SSL test' was created with a `checkrate` of 86,400.)

Output against this patch:

```
after create: &{ID:166245 Domain:https://www.google.com Checkrate:86400 ContactGroupsC: AlertAt:2,7,14 AlertReminder:false AlertExpiry:false AlertBroken:false AlertMixed:false Paused:false IssuerCn: CertScore:0 CipherScore:0 CertStatus: Cipher: ValidFromUtc:0000-00-00 00:00:00 ValidUntilUtc:0000-00-00 00:00:00 MixedContent:[] Flags:map[has_mixed:false has_pfs:true is_broken:false is_expired:false is_extended:false is_missing:false is_revoked:false] ContactGroups:[] LastReminder:0 LastUpdatedUtc:0000-00-00 00:00:00}
after update: &{ID:166245 Domain:https://www.google.com Checkrate:600 ContactGroupsC: AlertAt:2,7,14 AlertReminder:false AlertExpiry:false AlertBroken:false AlertMixed:false Paused:false IssuerCn: CertScore:0 CipherScore:0 CertStatus: Cipher: ValidFromUtc:0000-00-00 00:00:00 ValidUntilUtc:0000-00-00 00:00:00 MixedContent:[] Flags:map[has_mixed:false has_pfs:true is_broken:false is_expired:false is_extended:false is_missing:false is_revoked:false] ContactGroups:[] LastReminder:0 LastUpdatedUtc:2020-01-20 14:30:12}
```

(Upstream silently override our requested `checkrate` with 86,400 on create.)

Of course, this still works if we create an 'SSL test' with a `checkrate` of 600 or higher.  In this next case, we create with 600 and update with 3600:

```
after create: &{ID:166247 Domain:https://www.google.com Checkrate:600 ContactGroupsC: AlertAt:2,7,14 AlertReminder:false AlertExpiry:false AlertBroken:false AlertMixed:false Paused:false IssuerCn: CertScore:0 CipherScore:0 CertStatus: Cipher: ValidFromUtc:0000-00-00 00:00:00 ValidUntilUtc:0000-00-00 00:00:00 MixedContent:[] Flags:map[has_mixed:false has_pfs:true is_broken:false is_expired:false is_extended:false is_missing:false is_revoked:false] ContactGroups:[] LastReminder:0 LastUpdatedUtc:0000-00-00 00:00:00}
after update: &{ID:166247 Domain:https://www.google.com Checkrate:3600 ContactGroupsC: AlertAt:2,7,14 AlertReminder:false AlertExpiry:false AlertBroken:false AlertMixed:false Paused:false IssuerCn: CertScore:0 CipherScore:0 CertStatus: Cipher: ValidFromUtc:0000-00-00 00:00:00 ValidUntilUtc:0000-00-00 00:00:00 MixedContent:[] Flags:map[has_mixed:false has_pfs:true is_broken:false is_expired:false is_extended:false is_missing:false is_revoked:false] ContactGroups:[] LastReminder:0 LastUpdatedUtc:2020-01-20 14:44:36}
```