### PR TITLE
Feature: Added support for PostBody attribute

### DIFF
--- a/fixtures/tests_detail_ok.json
+++ b/fixtures/tests_detail_ok.json
@@ -33,6 +33,7 @@
   "DownTimes": "0",
   "UseJar": 0,
   "PostRaw": "",
+  "PostBody": "",
   "FinalEndpoint": "",
   "EnableSSLWarning": false,
   "FollowRedirect": false

--- a/fixtures/tests_dns_detail_ok.json
+++ b/fixtures/tests_dns_detail_ok.json
@@ -35,6 +35,7 @@
   "DNSServer": "1.1.1.1",
   "CustomHeader": "",
   "PostRaw": "",
+  "PostBody": "",
   "UseJar": 0,
   "StatusCodes": []
 }

--- a/responses.go
+++ b/responses.go
@@ -60,6 +60,7 @@ type detailResponse struct {
 	TriggerRate      int                          `json:"TriggerRate,string"`
 	UseJar           int                          `json:"UseJar"`
 	PostRaw          string                       `json:"PostRaw"`
+	PostBody         string                       `json:"PostBody"`
 	FinalEndpoint    string                       `json:"FinalEndpoint"`
 	EnableSSLWarning bool                         `json:"EnableSSLWarning"`
 	FollowRedirect   bool                         `json:"FollowRedirect"`
@@ -99,6 +100,7 @@ func (d *detailResponse) test() *Test {
 		TriggerRate:    d.TriggerRate,
 		UseJar:         d.UseJar,
 		PostRaw:        d.PostRaw,
+		PostBody:       d.PostBody,
 		FinalEndpoint:  d.FinalEndpoint,
 		DNSServer:      d.DNSServer,
 		DNSIP:          d.DNSIP,

--- a/tests.go
+++ b/tests.go
@@ -107,6 +107,9 @@ type Test struct {
 	// Raw POST data seperated by an ampersand
 	PostRaw string `json:"PostRaw" querystring:"PostRaw"`
 
+	// POST Body data, json
+	PostBody string `json:"PostBody" querystring:"PostBody"`
+
 	// Use to specify the expected Final URL in the testing process
 	FinalEndpoint string `json:"FinalEndpoint" querystring:"FinalEndpoint"`
 
@@ -168,7 +171,11 @@ func (t *Test) Validate() error {
 	}
 
 	if t.PostRaw != "" && t.TestType != "HTTP" {
-		e["PostRaw"] = "must be HTTP to submit a POST request"
+		e["PostRaw"] = "must be HTTP to submit a POST request with PostRaw"
+	}
+
+	if t.PostBody != "" && t.TestType != "HTTP" {
+		e["PostBody"] = "must be HTTP to submit a POST request with PostBody"
 	}
 
 	if t.FinalEndpoint != "" && t.TestType != "HTTP" {

--- a/tests_test.go
+++ b/tests_test.go
@@ -155,6 +155,7 @@ func TestTest_ToURLValues(t *testing.T) {
 		"StatusCodes":    {"500"},
 		"UseJar":         {"0"},
 		"PostRaw":        {""},
+		"PostBody":        {""},
 		"FinalEndpoint":  {""},
 		"EnableSSLAlert": {"0"},
 		"FollowRedirect": {"0"},


### PR DESCRIPTION
StatusCake has 2 kinds of POST data in the HTTP tests:
- PostRaw: This is sent as is to the test url and usually used for sending json content.
- PostBody: This is sent as formdata to the test url. Users need to specify it in JSON where each key becomes a form attribute.


Why add this feature?
- Enabling the consumer of this client to use an existing feature on StatusCake HTTP API.